### PR TITLE
GitHub installation support and enhanced release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
-name: Publish to PyPI
+name: Publish Package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, master ]
+    tags:
+      - 'v*'
   release:
     types: [created]
 
@@ -29,7 +31,7 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     steps:
     - uses: actions/checkout@v4
       with:
@@ -45,40 +47,52 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine build packaging
     
-    - name: Check version bump
-      if: github.event_name == 'push'
-      id: check_version
+    - name: Extract version
+      id: extract_version
       run: |
-        # Get the current version from setup.py
-        CURRENT_VERSION=$(python -c "from setuptools import setup; setup()" --version 2>/dev/null)
-        echo "Current version: $CURRENT_VERSION"
-        
-        # Get the latest published version from PyPI
-        LATEST_VERSION=$(python -c "import json, urllib.request; print(json.loads(urllib.request.urlopen('https://pypi.org/pypi/ranch/json').read())['info']['version'])")
-        echo "Latest published version: $LATEST_VERSION"
-        
-        # Compare versions using packaging
-        python -c "from packaging import version; current=version.parse('$CURRENT_VERSION'); latest=version.parse('$LATEST_VERSION'); exit(0 if current > latest else 1)" && SHOULD_PUBLISH=true || SHOULD_PUBLISH=false
-        echo "Should publish: $SHOULD_PUBLISH"
-        
-        echo "should_publish=$SHOULD_PUBLISH" >> $GITHUB_OUTPUT
+        if [[ $GITHUB_REF == refs/tags/v* ]]; then
+          TAG=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$TAG" >> $GITHUB_OUTPUT
+          echo "Tag version: $TAG"
+        else
+          VERSION=$(python -c "from setuptools import setup; setup()" --version 2>/dev/null)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Package version: $VERSION"
+        fi
     
     - name: Build and package
       run: |
         python -m build
     
+    - name: Create GitHub Release
+      id: create_release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          dist/*.whl
+          dist/*.tar.gz
+        name: Release ${{ steps.extract_version.outputs.VERSION }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+    
     - name: Publish to PyPI for releases
-      if: github.event_name == 'release'
+      if: (github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')) && env.PYPI_ENABLED == 'true'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip_existing: true
+      env:
+        PYPI_ENABLED: ${{ secrets.PYPI_ENABLED || 'false' }}
     
     - name: Publish to PyPI for version bumps
-      if: github.event_name == 'push' && steps.check_version.outputs.should_publish == 'true'
+      if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v') && env.PYPI_ENABLED == 'true'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip_existing: true
+      env:
+        PYPI_ENABLED: ${{ secrets.PYPI_ENABLED || 'false' }}

--- a/ENHANCEMENTS.md
+++ b/ENHANCEMENTS.md
@@ -2,6 +2,56 @@
 
 This document summarizes the enhancements made to the Ranch library to improve its reliability, performance, and feature set.
 
+## GitHub Installation Support
+
+While PyPI registrations are temporarily unavailable, we've added support for installing the package directly from GitHub.
+
+### Installation Methods
+
+#### Basic Installation
+```bash
+pip install git+https://github.com/teleos-consulting/celery-ranch.git
+```
+
+#### Version-specific Installation
+```bash
+pip install git+https://github.com/teleos-consulting/celery-ranch.git@v0.1.0
+```
+
+#### Installation with Redis Support
+```bash
+pip install "git+https://github.com/teleos-consulting/celery-ranch.git#egg=celery-ranch[redis]"
+```
+
+### GitHub Release Automation
+
+We've enhanced our GitHub Actions workflows to:
+
+1. Automatically create GitHub Releases when version tags are pushed
+2. Attach built package distributions to GitHub Releases
+3. Conditionally publish to PyPI (when it becomes available again)
+4. Support tag-based versioning
+
+### How to Tag a Version
+
+To create a new release:
+
+```bash
+# Ensure changes are committed to main/master
+git checkout main
+git pull
+
+# Create and push a version tag
+git tag v0.1.1
+git push origin v0.1.1
+```
+
+This will trigger the GitHub Actions workflow to:
+1. Run tests
+2. Build package distributions
+3. Create a GitHub Release with attached distributions
+4. (Conditionally) Publish to PyPI if PYPI_ENABLED secret is set to 'true'
+
 ## Implemented Enhancements
 
 ### 1. Redis Connection Handling

--- a/README.md
+++ b/README.md
@@ -12,13 +12,24 @@ A Python extension library for Celery that provides fair task scheduling using L
 ## Installation
 
 ```bash
+# Install from PyPI (currently unavailable)
 pip install celery-ranch
+
+# Install directly from GitHub
+pip install git+https://github.com/teleos-consulting/celery-ranch.git
+
+# Install a specific version from GitHub
+pip install git+https://github.com/teleos-consulting/celery-ranch.git@v0.1.0
 ```
 
 For production use with Redis storage:
 
 ```bash
+# From PyPI (currently unavailable)
 pip install celery-ranch[redis]
+
+# From GitHub
+pip install "git+https://github.com/teleos-consulting/celery-ranch.git#egg=celery-ranch[redis]"
 ```
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![Celery 5.3.4+](https://img.shields.io/badge/celery-5.3.4+-green.svg)](https://docs.celeryproject.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Sponsor on GitHub](https://img.shields.io/badge/sponsor-on%20github-blue?logo=github&style=flat-square)](https://github.com/sponsors/teleos-consulting)
 
 A Python extension library for Celery that provides fair task scheduling using LRU (Least Recently Used) prioritization. Designed to prevent high-volume bulk processes from monopolizing resources while ensuring fair access for all task sources - whether they're from bulk operations, user interactions, scheduled jobs, or critical on-demand processes.
 
@@ -251,8 +252,6 @@ This automation ensures that new versions are released as soon as approved chang
 ## Supporting Celery Ranch
 
 If you find Celery Ranch useful in your projects, please consider supporting its development! See our [Sponsorship Guide](docs/sponsorship.md) for more information on how you can contribute.
-
-[![Sponsor on GitHub](https://img.shields.io/badge/sponsor-on%20github-blue?logo=github&style=flat-square)](https://github.com/sponsors/teleos-consulting)
 
 ## License
 

--- a/docs/pypi_publishing.md
+++ b/docs/pypi_publishing.md
@@ -1,8 +1,23 @@
-# Publishing Ranch to PyPI
+# Publishing Ranch to PyPI or GitHub
 
-This document provides instructions for publishing the Ranch package to the Python Package Index (PyPI).
+This document provides instructions for publishing the Ranch package to the Python Package Index (PyPI) or making it installable from GitHub.
 
-## Prerequisites
+## Installation from GitHub
+
+While PyPI registrations are temporarily unavailable, you can install the package directly from GitHub using pip:
+
+```bash
+# Install the latest version
+pip install git+https://github.com/teleos-consulting/celery-ranch.git
+
+# Install a specific version by tag
+pip install git+https://github.com/teleos-consulting/celery-ranch.git@v0.1.0
+
+# Install with Redis support
+pip install "git+https://github.com/teleos-consulting/celery-ranch.git#egg=celery-ranch[redis]"
+```
+
+## Prerequisites for PyPI Publishing
 
 1. You need an account on [PyPI](https://pypi.org/) and/or [TestPyPI](https://test.pypi.org/)
 2. Generate API tokens from your PyPI/TestPyPI account settings


### PR DESCRIPTION
## Summary
- Add GitHub installation instructions as alternative to PyPI
- Enhance GitHub Actions workflow to support releases and tags
- Add documentation for installation from GitHub
- Enable package distribution via GitHub Releases
- Move donation/sponsor button to top badge section for better visibility

## Test plan
- Verify installation using GitHub URL syntax works
- Ensure GitHub Actions release workflow functions correctly with tags
- Confirm documentation accurately reflects installation options
- Check that sponsor button displays correctly with other badges

🤖 Generated with [Claude Code](https://claude.ai/code)